### PR TITLE
Use path.join for check of files in path_tmpl

### DIFF
--- a/cases.py
+++ b/cases.py
@@ -414,7 +414,7 @@ class Exp():
       signal = True
       for file_template in self.file_templates:
               tmp = {}
-              x,mk,replace_keys = self.check_template(part_path+file_template)
+              x,mk,replace_keys = self.check_template(os.path.join(part_path,file_template))
               for cc in content:
                  zz = re.findall(r""+x+'$',cc)
                  if len(zz) > 0:


### PR DESCRIPTION
This is only a tiny adaption to avoid problems if anyone else is missing a trailing '/' in the path_template of the meta.yaml, as I did. If this is missing no data were found when running ./chase.py -scan...

Using os.path.join allows both, paths with and without trailing '/'. 
Hopefully this saves some time for anyone else who also carelessly is lacking the '/' at the end of the path_template.